### PR TITLE
👌 IMPROVE: prevent CLI from being created without a name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "create-node-cli",
 			"version": "1.6.1",
 			"dependencies": {
 				"await-to-js": "^3.0.0",

--- a/utils/ask.js
+++ b/utils/ask.js
@@ -38,7 +38,7 @@ module.exports = async ({ name, message, hint, initial }) => {
 					if (fs.existsSync(value)) {
 						return `Directory already exists: ./${value}`;
 					} else {
-						return true;
+						return !value ? `Please add a value.` : true;
 					}
 				}
 				return !value ? `Please add a value.` : true;


### PR DESCRIPTION
Currently, user is able to press 'Enter' without supplying a value, when prompted for the CLI name (first prompt).

As a result, the generated CLI is created in the same directory, and the `package.json` file has empty `"name"` and `"bin"` keys. This pull request adds the validation to prevent this issue.

```json
{
	"name": "",
	"description": "break",
	"version": "0.0.1",
	"license": "UNLICENSED",
	"bin": {
		"": "index.js"
	},
	"author": {
		"name": "break",
		"email": "break",
		"url": "break"
	},
	"keywords": [
		"",
		"break"
	],
	"files": [
		"index.js",
		"utils"
	],
	"scripts": {
		"format": "prettier --write \"./**/*.{js,json}\""
	},
	"dependencies": {
		"chalk": "^4.1.2",
		"cli-alerts": "^1.2.2",
		"cli-handle-error": "^4.4.0",
		"cli-handle-unhandled": "^1.1.1",
		"cli-meow-help": "^3.1.0",
		"cli-welcome": "^2.2.2",
		"meow": "^9.0.0"
	},
	"devDependencies": {
		"prettier": "^2.6.2"
	}
}
```